### PR TITLE
Fix/auth: 로그인/회원가입 페이지 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/Layout";
 import LoginPage from "./pages/auth/LoginPage";
+import SignupPage from "./pages/auth/SignupPage";
 import B2CSignupPage from "./pages/auth/B2CSignupPage";
 import B2BSignupPage from "./pages/auth/B2BSignupPage";
+import SignupComplete from "./components/auth/signup/common/SignupComplete.jsx";
 import { SubscribePage } from "./pages/b2b/SubscribePage";
 import { DownloadePage } from "./pages/b2b/DownloadPage";
-import SignupComplete from "./components/auth/signup/common/SignupComplete.jsx";
 import B2BHome from "./pages/b2b/B2BHomePage";
 import { B2BMyPage } from "./pages/b2b/B2BMyPage";
 import { UserHomePage } from "./pages/user/UserHomePage";
@@ -25,6 +26,7 @@ function App() {
           <Route path="/" element={<RouteSwitch role={"user"} />} />
           {/* 공통 페이지 */}
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
           <Route path="/signup/b2c" element={<B2CSignupPage />} />
           <Route path="/signup/b2b" element={<B2BSignupPage />} />
           <Route path="/signup/complete" element={<SignupComplete />} />

--- a/src/components/auth/login/Login.scss
+++ b/src/components/auth/login/Login.scss
@@ -127,7 +127,7 @@
 }
 
 .login-links {
-  margin-top: rem(20px);
+  margin-top: rem(32px);
   @include flex(row, center, center, rem(40px));
 
   .link {
@@ -138,37 +138,5 @@
   }
   .divider {
     color: #dddddd;
-  }
-}
-
-.login-helper-chip {
-  position: relative;
-  margin: rem(10px) auto 0;
-  width: max-content;
-  background: linear-gradient(90deg, #dcd2f4, #ede7fa);
-  color: #4f4376;
-  padding: rem(7px) rem(12px);
-  border-radius: 20px;
-  font-size: rem(10px);
-
-  // 말풍선 꼬리
-  &::before {
-    content: "";
-    position: absolute;
-    top: -6px;
-    border-width: 0 6px 6px 6px;
-    border-style: solid;
-  }
-
-  // 손님(왼쪽 꼬리)
-  &.left::before {
-    left: rem(28px);
-    border-color: transparent transparent #dcd2f4 transparent;
-  }
-
-  // 사장님(오른쪽 꼬리)
-  &.right::before {
-    right: rem(28px);
-    border-color: transparent transparent #ede7fa transparent;
   }
 }

--- a/src/components/auth/login/LoginForm.jsx
+++ b/src/components/auth/login/LoginForm.jsx
@@ -97,8 +97,8 @@ export default function LoginForm({ role, onError, onSuccess }) {
         </button>
       </div>
 
-      <button type="submit" className="btn-primary" disabled={isSubmitting}>
-        {isSubmitting ? "처리 중..." : "로그인"}
+      <button type="submit" className="btn-primary" disabled={pending}>
+        로그인
       </button>
     </form>
   );

--- a/src/components/auth/login/LoginForm.jsx
+++ b/src/components/auth/login/LoginForm.jsx
@@ -97,7 +97,7 @@ export default function LoginForm({ role, onError, onSuccess }) {
         </button>
       </div>
 
-      <button type="submit" className="btn-primary" disabled={pending}>
+      <button type="submit" className="btn-primary" disabled={isSubmitting}>
         로그인
       </button>
     </form>

--- a/src/components/auth/login/LoginScreen.jsx
+++ b/src/components/auth/login/LoginScreen.jsx
@@ -22,19 +22,8 @@ const LoginScreen = () => {
 
         <div className="login-links">
           <Link to="/signup/b2c" className="link">
-            손님 회원 가입
+            회원 가입
           </Link>
-          <span className="divider" aria-hidden>
-            │
-          </span>
-          <Link to="/signup/b2b" className="link">
-            스토어 사장님 가입
-          </Link>
-        </div>
-
-        {/* TODO: 말풍선 위치 디테일 수정 예정 */}
-        <div className={`login-helper-chip ${role === "guest" ? "left" : "right"}`}>
-          지금 가입하고 빠르게 소식을 접해보세요!
         </div>
       </div>
 

--- a/src/components/auth/login/LoginScreen.jsx
+++ b/src/components/auth/login/LoginScreen.jsx
@@ -21,7 +21,7 @@ const LoginScreen = () => {
         <LoginForm role={role} onError={(msg) => setModalMsg(msg)} onSuccess={() => setModalMsg("")} />
 
         <div className="login-links">
-          <Link to="/signup/b2c" className="link">
+          <Link to="/signup" className="link">
             회원 가입
           </Link>
         </div>

--- a/src/components/auth/signup/b2b/BusinessForm.jsx
+++ b/src/components/auth/signup/b2b/BusinessForm.jsx
@@ -9,8 +9,8 @@ function Row({ children }) {
   return <div className="row">{children}</div>;
 }
 
-// 사업자번호 형식 (하이픈 없어도 허용)
-const BIZNO_RE = /^\d{3}-?\d{2}-?\d{5}$/;
+// 사업자번호 형식 (하이픈 필수)
+const BIZNO_RE = /^\d{3}-\d{2}-\d{5}$/;
 
 export default function BusinessForm({ defaultValues, onSubmit, submitting, headerOnBack }) {
   const {

--- a/src/components/auth/signup/b2b/BusinessForm.jsx
+++ b/src/components/auth/signup/b2b/BusinessForm.jsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import React from "react";
+import { useForm } from "react-hook-form";
 import "../common/SignupCommonForm.scss";
 import SignupHeader from "../common/SignupHeader.jsx";
 import BrandHeading from "../common/BrandHeading.jsx";
@@ -11,39 +12,40 @@ function Row({ children }) {
 // 사업자번호 형식 (하이픈 없어도 허용)
 const BIZNO_RE = /^\d{3}-?\d{2}-?\d{5}$/;
 
-export default function BusinessForm({ values, onChange, onSubmit, submitting, headerOnBack, onFindZip }) {
-  const isAllFilled = useMemo(() => {
-    const req = [
-      values.bizName,
-      values.owner,
-      values.bizNo,
-      values.bizType,
-      values.bizCategory,
-      values.zip,
-      values.addr1,
-      values.addr2,
-    ];
-    return req.every((v) => String(v ?? "").trim().length > 0);
-  }, [values]);
+export default function BusinessForm({ defaultValues, onSubmit, submitting, headerOnBack }) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      bizName: "",
+      owner: "",
+      bizNo: "",
+      bizType: "",
+      bizCategory: "",
+      zip: "",
+      addr1: "",
+      addr2: "",
+      ...(defaultValues || {}),
+    },
+  });
 
-  // 사업자번호 유효성 검사
-  const isBizNoValid = useMemo(() => {
-    const v = String(values.bizNo ?? "").trim();
-    return v.length === 0 ? false : BIZNO_RE.test(v);
-  }, [values.bizNo]);
+  const onValid = async (data) => {
+    await onSubmit?.(data);
+  };
 
-  // 버튼 활성화 (모든 입력 형식이 맞으면)
-  const isValid = isAllFilled && isBizNoValid;
-
-  // 사업자번호 에러 표시
-  const showBizNoError = String(values.bizNo ?? "").trim().length > 0 && !isBizNoValid;
+  const bizNoValue = watch("bizNo") ?? "";
+  const showBizNoError = bizNoValue.trim().length > 0 && !!errors.bizNo;
 
   return (
     <>
       <SignupHeader rightLabel="사업정보 입력" onBack={headerOnBack} />
       <BrandHeading title={"가입하기 위해\n사업정보를 입력해주세요"} />
 
-      <form className="signup-form" onSubmit={(e) => onSubmit?.(e)}>
+      <form className="signup-form" onSubmit={handleSubmit(onValid)}>
         {/* 상호 */}
         <div className="form-field">
           <label className="form-label" htmlFor="bizName">
@@ -52,10 +54,8 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <input
             id="bizName"
             className="input"
-            name="bizName"
-            value={values.bizName}
-            onChange={onChange}
             autoComplete="organization"
+            {...register("bizName", { required: true })}
           />
         </div>
 
@@ -64,14 +64,7 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <label className="form-label" htmlFor="owner">
             대표자명
           </label>
-          <input
-            id="owner"
-            className="input"
-            name="owner"
-            value={values.owner}
-            onChange={onChange}
-            autoComplete="name"
-          />
+          <input id="owner" className="input" autoComplete="name" {...register("owner", { required: true })} />
         </div>
 
         {/* 사업자 번호 */}
@@ -82,17 +75,18 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <input
             id="bizNo"
             className={`input ${showBizNoError ? "has-error" : ""}`}
-            name="bizNo"
-            value={values.bizNo}
-            onChange={onChange}
-            inputMode="numeric"
             placeholder="000-00-00000"
+            inputMode="numeric"
             aria-invalid={showBizNoError ? "true" : "false"}
             aria-describedby="bizNo-error"
+            {...register("bizNo", {
+              required: true,
+              validate: (v) => BIZNO_RE.test((v ?? "").trim()) || "*사업자 번호가 일치하지 않습니다.",
+            })}
           />
           {showBizNoError && (
             <p id="bizNo-error" className="field-error">
-              *사업자 번호가 일치하지 않습니다.
+              {errors.bizNo?.message || "*사업자 번호가 일치하지 않습니다."}
             </p>
           )}
         </div>
@@ -102,7 +96,7 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <label className="form-label" htmlFor="bizType">
             업태
           </label>
-          <input id="bizType" className="input" name="bizType" value={values.bizType} onChange={onChange} />
+          <input id="bizType" className="input" {...register("bizType", { required: true })} />
         </div>
 
         {/* 업종 */}
@@ -110,7 +104,7 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <label className="form-label" htmlFor="bizCategory">
             업종
           </label>
-          <input id="bizCategory" className="input" name="bizCategory" value={values.bizCategory} onChange={onChange} />
+          <input id="bizCategory" className="input" {...register("bizCategory", { required: true })} />
         </div>
 
         {/* 사업장 주소 - 우편번호 */}
@@ -122,14 +116,13 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
             <input
               id="zip"
               className="input"
-              name="zip"
               placeholder="우편번호"
-              value={values.zip}
-              onChange={onChange}
               inputMode="numeric"
               autoComplete="postal-code"
+              {...register("zip", { required: true })}
             />
-            <Button type="button" variant="ghost" onClick={onFindZip}>
+            {/* TODO: 카카오 주소 API 연결 (우편번호 찾기) */}
+            <Button type="button" variant="ghost">
               우편번호 찾기
             </Button>
           </Row>
@@ -139,12 +132,10 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <input
             id="addr1"
             className="input"
-            name="addr1"
             placeholder="주소"
-            value={values.addr1}
-            onChange={onChange}
             autoComplete="street-address"
             aria-label="주소"
+            {...register("addr1", { required: true })}
           />
         </div>
 
@@ -152,18 +143,16 @@ export default function BusinessForm({ values, onChange, onSubmit, submitting, h
           <input
             id="addr2"
             className="input"
-            name="addr2"
             placeholder="상세주소"
-            value={values.addr2}
-            onChange={onChange}
             autoComplete="address-line2"
             aria-label="상세주소"
+            {...register("addr2", { required: true })}
           />
         </div>
 
         <Button
           type="submit"
-          disabled={!isValid || submitting}
+          disabled={!isValid || isSubmitting || submitting}
           className={`w-full ${isValid ? "btn-enabled" : "btn-disabled"}`}>
           다음으로
         </Button>

--- a/src/components/auth/signup/common/SignupCommonForm.jsx
+++ b/src/components/auth/signup/common/SignupCommonForm.jsx
@@ -15,6 +15,7 @@ export default function SignupCommonForm({ onSubmit, submitting, submitLabel = "
   } = useForm({
     mode: "onChange",
     defaultValues: {
+      nickname: "",
       username: "",
       password: "",
       passwordConfirm: "",
@@ -31,6 +32,25 @@ export default function SignupCommonForm({ onSubmit, submitting, submitLabel = "
       <BrandHeading title={"회원님의 정보를\n입력해주세요"} />
 
       <form className="signup-form" onSubmit={handleSubmit(onValid)}>
+        {/* 닉네임 */}
+        <div className="form-field">
+          <label className="form-label" htmlFor="nickname">
+            닉네임
+          </label>
+          <input
+            id="nickname"
+            className={`input ${errors.nickname ? "has-error" : ""}`}
+            placeholder="10자 이내"
+            autoComplete="nickname"
+            maxLength={10}
+            {...register("nickname", {
+              required: true,
+              maxLength: { value: 10, message: "*10자 이내로 작성해주세요." },
+            })}
+          />
+          {errors.nickname && <p className="field-error">{errors.nickname.message || "*10자 이내로 작성해주세요."}</p>}
+        </div>
+
         {/* 아이디 */}
         <div className="form-field">
           <label className="form-label" htmlFor="username">

--- a/src/components/auth/signup/common/SignupCommonForm.scss
+++ b/src/components/auth/signup/common/SignupCommonForm.scss
@@ -23,10 +23,14 @@
 .input {
   width: 100%;
   padding: rem(18px) rem(20px) rem(18px) rem(17px);
-  border: rem(1px) solid #dddddd;
+  border: rem(1px) solid #cfcfcf;
   border-radius: rem(12px);
   font-size: rem(14px);
   font-weight: 500;
+
+  &::placeholder {
+    color: #cfcfcf;
+  }
 
   &:focus {
     outline: none;

--- a/src/components/auth/signup/common/SignupComplete.jsx
+++ b/src/components/auth/signup/common/SignupComplete.jsx
@@ -17,7 +17,7 @@ export default function SignupComplete() {
 
       <div className="signup-complete">
         <img className="complete-mascot" src={mascot} alt="스토어리 캐릭터" />
-        <Button type="button" onClick={goStart} className="start-btn">
+        <Button type="button" onClick={goStart} className="start-btn btn-enabled">
           스토어리 시작하기
         </Button>
       </div>

--- a/src/components/auth/signup/common/SignupSelect.jsx
+++ b/src/components/auth/signup/common/SignupSelect.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import SignupHeader from "./SignupHeader.jsx";
+import BrandHeading from "./BrandHeading.jsx";
+import Button from "./Button.jsx";
+import "./SignupSelect.scss";
+import "./SignupCommonForm.scss";
+
+export default function SignupSelect() {
+  const nav = useNavigate();
+  const [type, setType] = useState(null);
+
+  const goNext = () => {
+    if (type === "b2c") nav("/signup/b2c");
+    if (type === "b2b") nav("/signup/b2b");
+  };
+
+  return (
+    <>
+      <SignupHeader rightLabel="회원가입" onBack={() => nav(-1)} />
+      <BrandHeading title={"가입 유형을\n선택해주세요"} />
+
+      <div className="signup-select">
+        <button
+          type="button"
+          className={`select-card ${type === "b2c" ? "active" : ""}`}
+          onClick={() => setType("b2c")}
+          aria-pressed={type === "b2c"}>
+          손님
+        </button>
+
+        <button
+          type="button"
+          className={`select-card ${type === "b2b" ? "active" : ""}`}
+          onClick={() => setType("b2b")}
+          aria-pressed={type === "b2b"}>
+          스토어 사장님
+        </button>
+
+        <div className="next-btn">
+          <Button
+            type="button"
+            onClick={goNext}
+            disabled={!type}
+            className={`w-full ${type ? "btn-enabled" : "btn-disabled"}`}>
+            다음으로
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/auth/signup/common/SignupSelect.scss
+++ b/src/components/auth/signup/common/SignupSelect.scss
@@ -1,0 +1,34 @@
+@use "../../../../styles/function" as *;
+@use "../../../../styles/variables" as *;
+
+.signup-select {
+  padding: rem(66px) rem(30px) rem(28px);
+
+  .next-btn {
+    margin-top: rem(135px);
+  }
+}
+
+.select-card {
+  width: 100%;
+  text-align: left;
+  padding: rem(32px) rem(30px);
+  border-radius: rem(15px);
+  border: rem(1px) solid #f0f0f0;
+  background: #f0f0f0;
+  font-size: rem(20px);
+  font-weight: 600;
+  color: #cbcbcb;
+  margin-bottom: rem(14px);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &.active {
+    background: rgba($color-primary, 0.08);
+    border-color: $color-primary;
+    color: $color-primary;
+  }
+}

--- a/src/pages/auth/B2BSignupPage.jsx
+++ b/src/pages/auth/B2BSignupPage.jsx
@@ -3,43 +3,25 @@ import SignupCommonForm from "@/components/auth/signup/common/SignupCommonForm";
 import BusinessForm from "@/components/auth/signup/b2b/BusinessForm";
 import { useNavigate } from "react-router-dom";
 
-const initBiz = {
-  bizName: "",
-  owner: "",
-  bizNo: "",
-  bizType: "",
-  bizCategory: "",
-  zip: "",
-  addr1: "",
-  addr2: "",
-};
-
 const B2BSignupPage = () => {
   const [step, setStep] = useState(1);
   const [accountData, setAccountData] = useState(null);
-  const [biz, setBiz] = useState(initBiz);
   const [submitting, setSubmitting] = useState(false);
   const nav = useNavigate();
 
-  const onBizChange = (e) => {
-    const { name, value } = e.target;
-    setBiz((v) => ({ ...v, [name]: value }));
-  };
-
-  const clearBiz = (name) => setBiz((v) => ({ ...v, [name]: "" }));
-
   // 1단계: 계정 정보 입력 후 2단계로 이동
   const handleAccountSubmit = async (data) => {
-    setAccountData({ username: data.username, password: data.password });
+    const { username, password, nickname } = data;
+    setAccountData({ username, password, nickname });
     setStep(2);
   };
 
-  const submitAll = async (e) => {
-    e.preventDefault();
+  // 2단계: 사업자 정보 입력 후 가입 완료
+  const handleBusinessSubmit = async (bizData) => {
     try {
       setSubmitting(true);
       // TODO: API 연동
-      console.log("B2B 가입", { account: accountData, business: biz });
+      console.log("B2B 가입", { account: accountData, business: bizData });
       nav("/signup/complete");
     } finally {
       setSubmitting(false);
@@ -51,14 +33,7 @@ const B2BSignupPage = () => {
       {step === 1 && <SignupCommonForm onSubmit={handleAccountSubmit} submitting={submitting} submitLabel="다음으로" />}
 
       {step === 2 && (
-        <BusinessForm
-          headerOnBack={() => setStep(1)}
-          values={biz}
-          onChange={onBizChange}
-          onSubmit={submitAll}
-          submitting={submitting}
-          clear={clearBiz}
-        />
+        <BusinessForm headerOnBack={() => setStep(1)} onSubmit={handleBusinessSubmit} submitting={submitting} />
       )}
     </div>
   );

--- a/src/pages/auth/B2CSignupPage.jsx
+++ b/src/pages/auth/B2CSignupPage.jsx
@@ -19,7 +19,7 @@ const B2CSignupPage = () => {
 
   return (
     <div>
-      <SignupCommonForm onSubmit={submit} submitting={submitting} submitLabel="가입하기" />
+      <SignupCommonForm onSubmit={submit} submitting={submitting} />
     </div>
   );
 };

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Signuppage = () => {
+  return <div>Signuppage</div>;
+};
+
+export default Signuppage;

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -1,7 +1,10 @@
 import React from "react";
-
+import SignupSelect from "../../components/auth/signup/common/SignupSelect";
 const Signuppage = () => {
-  return <div>Signuppage</div>;
+  return (
+    <div>
+      <SignupSelect />
+    </div>
+  );
 };
-
 export default Signuppage;


### PR DESCRIPTION
## ✨ 작업 개요

로그인/회원가입 페이지 수정

## 📌 관련 이슈

- close #19 

## 📄 작업 내용

- 로그인 페이지 UI 수정 (피그마 수정 버전)
- 회원가입 손님/사장님 유형 검사 페이지 추가 구현 (피그마 수정 버전)
- 회원가입 페이지 UI 수정 (피그마 수정 버전) + 닉네임 입력칸 구현
- 사업자 번호 유효성 검사 

## 📷 UI 스크린샷 (해당 시)

| 로그인 | 회원가입 유형 |
|--------|--------|
| <img width="315" height="682" alt="image" src="https://github.com/user-attachments/assets/15b58155-efc3-4e1a-bc49-6de0fe853f04" /> | <img width="317" height="681" alt="image" src="https://github.com/user-attachments/assets/ef58e47f-0a16-4a53-b14d-436ef665f1a7" /> |

| 회원가입 1단계 | 회원가입 2단계 |
|--------|--------|
| <img width="315" height="676" alt="image" src="https://github.com/user-attachments/assets/d0103df2-7fa9-4016-8e6b-349de72e7b41" /> | <img width="218" height="627" alt="image" src="https://github.com/user-attachments/assets/bf652559-23f2-4ec0-9ee6-100cba922cbc" /> |


## 💬 기타 사항

❗️우편번호 찾기 API 아직 미구현