### PR TITLE
Feat/api auth: 로그인/회원가입 API 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "html2canvas": "^1.4.1",
         "qr-scanner": "^1.4.2",
         "react": "^19.1.0",
+        "react-daum-postcode": "^3.2.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
@@ -3226,6 +3227,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.2.0.tgz",
+      "integrity": "sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "html2canvas": "^1.4.1",
     "qr-scanner": "^1.4.2",
     "react": "^19.1.0",
+    "react-daum-postcode": "^3.2.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.62.0",
     "react-icons": "^5.5.0",

--- a/src/apis/auth/loginApi.js
+++ b/src/apis/auth/loginApi.js
@@ -1,0 +1,21 @@
+// 로그인 API (POST) - 사징님/사용자 로그인 API 통합
+import api from "../Instance";
+
+const loginApi = async ({ role, loginId, password }) => {
+  try {
+    const path = role === "owner" ? "auth/owner/login" : "auth/user/login";
+    const { data: res } = await api.post(path, { loginId, password });
+    const { httpStatus, isSuccess, data, message } = res || {};
+
+    if (httpStatus === 200 && isSuccess && data?.accessToken) {
+      return { accessToken: data.accessToken, refreshToken: data.refreshToken };
+    }
+    console.log("로그인 실패:", message);
+    return null;
+  } catch (e) {
+    console.log("로그인 요청 오류:", e);
+    return null;
+  }
+};
+
+export default loginApi;

--- a/src/apis/auth/loginApi.js
+++ b/src/apis/auth/loginApi.js
@@ -1,21 +1,38 @@
 // 로그인 API (POST) - 사징님/사용자 로그인 API 통합
 import api from "../Instance";
 
-const loginApi = async ({ role, loginId, password }) => {
+const once = async ({ role, loginId, password }) => {
+  const path = role === "owner" ? "auth/owner/login" : "auth/user/login";
   try {
-    const path = role === "owner" ? "auth/owner/login" : "auth/user/login";
     const { data: res } = await api.post(path, { loginId, password });
-    const { httpStatus, isSuccess, data, message } = res || {};
-
+    const { httpStatus, isSuccess, data } = res || {};
     if (httpStatus === 200 && isSuccess && data?.accessToken) {
-      return { accessToken: data.accessToken, refreshToken: data.refreshToken };
+      return { ok: true, tokens: { accessToken: data.accessToken, refreshToken: data.refreshToken } };
     }
-    console.log("로그인 실패:", message);
-    return null;
+    return { ok: false, status: httpStatus || 400 };
   } catch (e) {
-    console.log("로그인 요청 오류:", e);
-    return null;
+    return { ok: false, status: e?.response?.status || 500 };
   }
+};
+
+const opposite = (role) => (role === "owner" ? "user" : "owner");
+
+const loginApi = async ({ role, loginId, password }) => {
+  const first = await once({ role, loginId, password });
+  if (first.ok) return { tokens: first.tokens };
+
+  if (first.status === 401) return { error: "invalid" };
+
+  if (first.status === 404) {
+    const otherRole = opposite(role);
+    const second = await once({ role: otherRole, loginId, password });
+    if (second.ok) return { mismatch: otherRole };
+    if (second.status === 401) return { error: "invalid" };
+    if (second.status === 404) return { error: "notfound" };
+    return { error: "server" };
+  }
+
+  return { error: "server" };
 };
 
 export default loginApi;

--- a/src/apis/auth/ownerStoreApi.js
+++ b/src/apis/auth/ownerStoreApi.js
@@ -1,3 +1,4 @@
+// 가게 정보 등록 API(POST)
 import api from "../Instance";
 
 const ownerStoreApi = async (payload) => {

--- a/src/apis/auth/ownerStoreApi.js
+++ b/src/apis/auth/ownerStoreApi.js
@@ -1,0 +1,26 @@
+import api from "../Instance";
+
+const ownerStoreApi = async (payload) => {
+  try {
+    const { data: res } = await api.post("owner/store", payload);
+    const { httpStatus, isSuccess, code, message } = res || {};
+
+    if (httpStatus === 201 && isSuccess) {
+      console.log("가게 정보 등록 성공");
+      return { ok: true };
+    }
+
+    console.log("가게 정보 등록 실패:", code || httpStatus, message);
+    return { ok: false, code: code || httpStatus, message };
+  } catch (e) {
+    const status = e?.response?.status;
+    const body = e?.response?.data;
+    return {
+      ok: false,
+      code: body?.httpStatus ?? status ?? 500,
+      message: body?.message || "요청 오류",
+    };
+  }
+};
+
+export default ownerStoreApi;

--- a/src/apis/auth/signupApi.js
+++ b/src/apis/auth/signupApi.js
@@ -6,7 +6,7 @@ const signupApi = async ({ loginId, password, nickName, role }) => {
     const res = await api.post("auth/signup", { loginId, password, nickName, role });
     const { httpStatus, isSuccess, data, message } = res.data || {};
 
-    if ((httpStatus === 201 || httpStatus === 200) && isSuccess) {
+    if (httpStatus === 201 && isSuccess) {
       console.log("회원가입 성공");
       return data?.id ?? data?.userId ?? true;
     }

--- a/src/apis/auth/signupApi.js
+++ b/src/apis/auth/signupApi.js
@@ -1,0 +1,27 @@
+// 통합 회원가입 API(POST)
+import api from "../Instance";
+
+const signupApi = async ({ loginId, password, nickName, role }) => {
+  try {
+    const res = await api.post("auth/signup", { loginId, password, nickName, role });
+    const { httpStatus, isSuccess, data, message } = res.data || {};
+
+    if ((httpStatus === 201 || httpStatus === 200) && isSuccess) {
+      console.log("회원가입 성공");
+      return { ok: true, id: data?.id ?? data?.userId ?? null };
+    }
+
+    if (httpStatus === 409) {
+      console.log("아이디 중복");
+      return { ok: false, code: 409, message };
+    }
+
+    console.log("회원가입 실패:", message);
+    return { ok: false, code: httpStatus, message };
+  } catch (e) {
+    console.log("회원가입 요청 오류:", e);
+    return { ok: false, code: 500, message: "요청 오류" };
+  }
+};
+
+export default signupApi;

--- a/src/apis/auth/signupApi.js
+++ b/src/apis/auth/signupApi.js
@@ -8,19 +8,19 @@ const signupApi = async ({ loginId, password, nickName, role }) => {
 
     if ((httpStatus === 201 || httpStatus === 200) && isSuccess) {
       console.log("회원가입 성공");
-      return { ok: true, id: data?.id ?? data?.userId ?? null };
+      return data?.id ?? data?.userId ?? true;
     }
 
     if (httpStatus === 409) {
       console.log("아이디 중복");
-      return { ok: false, code: 409, message };
+      return null;
     }
 
     console.log("회원가입 실패:", message);
-    return { ok: false, code: httpStatus, message };
+    return null;
   } catch (e) {
     console.log("회원가입 요청 오류:", e);
-    return { ok: false, code: 500, message: "요청 오류" };
+    return null;
   }
 };
 

--- a/src/components/auth/login/LoginForm.jsx
+++ b/src/components/auth/login/LoginForm.jsx
@@ -4,14 +4,13 @@ import { HiMiniEyeSlash } from "react-icons/hi2";
 import { ID_RE, PW_RE, normalizeId } from "../authRules.js";
 import { useAuthStore } from "@/store/useAuthStore.js";
 import { useNavigate } from "react-router-dom";
+import loginApi from "@/apis/auth/loginApi";
 
 const CREDENTIALS_ERROR = "아이디 또는 비밀번호가 올바르지 않습니다.";
-const GUEST_ACCOUNT_ERROR = "손님으로 가입된 계정입니다.";
-const OWNER_ACCOUNT_ERROR = "스토어 사장님으로 가입된 계정입니다.";
 
 export default function LoginForm({ role, onError, onSuccess }) {
   const [showPw, setShowPw] = useState(false);
-  const { login } = useAuthStore(); // role, isLoggedIn 전역 상태를 저장할 로그인 함수 가져오기
+  const { login } = useAuthStore();
   const {
     register,
     handleSubmit,
@@ -25,36 +24,25 @@ export default function LoginForm({ role, onError, onSuccess }) {
   const nav = useNavigate();
 
   const onValid = async ({ id, password }) => {
-    const idLower = normalizeId(id);
+    const loginId = normalizeId(id);
 
-    // 임시: 역할에 따라 계정 유형 확인
-    if (role === "owner" && idLower.startsWith("user")) {
-      onError?.(GUEST_ACCOUNT_ERROR);
-      reset({ id: "", password: "" });
-      setFocus("id");
-      return;
-    }
-    if (role === "user" && idLower.startsWith("owner")) {
-      onError?.(OWNER_ACCOUNT_ERROR);
-      reset({ id: "", password: "" });
-      setFocus("id");
-      return;
-    }
-
-    try {
-      // TODO: 로그인 API 연동
-      console.log(`로그인 시도 (${role})`, { id: idLower, password });
-      onSuccess?.();
-      login({ role: role }); // 전역 상태에 role값 저장. 성공할 때 호출하면 됨.
-      nav(`/home/${role}`); // 홈으로 이동. 성공할 때 호출하면 됨.
-    } catch (e) {
+    const tokens = await loginApi({ role, loginId, password });
+    if (!tokens) {
       onError?.(CREDENTIALS_ERROR);
       reset({ id: "", password: "" });
       setFocus("id");
+      return;
     }
+
+    localStorage.setItem("access_token", tokens.accessToken);
+    localStorage.setItem("refresh_token", tokens.refreshToken);
+
+    login({ role });
+
+    onSuccess?.();
+    nav(`/home/${role}`);
   };
 
-  // 유효성 검사 실패 시
   const onInvalid = () => {
     onError?.(CREDENTIALS_ERROR);
     reset({ id: "", password: "" });

--- a/src/components/auth/signup/b2b/AddressSearchModal.jsx
+++ b/src/components/auth/signup/b2b/AddressSearchModal.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useCallback } from "react";
+import ReactDOM from "react-dom";
+import DaumPostcode from "react-daum-postcode";
+import "./AddressSearchModal.scss";
+
+export default function AddressSearchModal({ open, onClose, onSelect }) {
+  const handleComplete = (data) => {
+    let fullAddress = data.address;
+    let extraAddress = "";
+
+    if (data.addressType === "R") {
+      if (data.bname) extraAddress += data.bname;
+      if (data.buildingName) {
+        extraAddress += extraAddress ? `, ${data.buildingName}` : data.buildingName;
+      }
+      if (extraAddress) fullAddress += ` (${extraAddress})`;
+    }
+
+    onSelect?.({
+      zonecode: data.zonecode,
+      address: fullAddress,
+      sido: data.sido,
+      sigungu: data.sigungu,
+      roadAddress: data.roadAddress,
+      jibunAddress: data.jibunAddress,
+    });
+    onClose?.();
+  };
+
+  const onKeyDown = useCallback(
+    (e) => {
+      if (e.key === "Escape") onClose?.();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", onKeyDown);
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = overflow;
+    };
+  }, [open, onKeyDown]);
+
+  if (!open) return null;
+
+  return ReactDOM.createPortal(
+    <div
+      className="address-modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose?.();
+      }}
+      aria-modal="true"
+      role="dialog">
+      <div className="address-modal">
+        <div className="address-modal__header">
+          <strong>주소 검색</strong>
+          <button type="button" className="address-modal__close" onClick={onClose} aria-label="닫기">
+            ×
+          </button>
+        </div>
+        <div className="address-modal__body">
+          <DaumPostcode onComplete={handleComplete} style={{ width: "100%", height: "100%" }} />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/auth/signup/b2b/AddressSearchModal.scss
+++ b/src/components/auth/signup/b2b/AddressSearchModal.scss
@@ -1,0 +1,49 @@
+@use "@/styles/function" as *;
+
+.address-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: rem(16px);
+  z-index: 1000;
+}
+
+.address-modal {
+  width: 100%;
+  max-width: rem(430px);
+  max-height: 90vh;
+  background: #fff;
+  border-radius: rem(12px);
+  overflow: hidden;
+  box-shadow: 0 rem(10px) rem(30px) rgba(0, 0, 0, 0.2);
+
+  @media (max-width: 480px) {
+    max-width: 90vw;
+  }
+
+  &__header {
+    height: rem(52px);
+    padding: 0 rem(16px);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #eee;
+  }
+
+  &__close {
+    border: none;
+    background: transparent;
+    font-size: rem(24px);
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  &__body {
+    width: 100%;
+    height: rem(480px);
+    max-height: calc(90vh - rem(52px));
+  }
+}

--- a/src/components/auth/signup/b2b/BusinessForm.jsx
+++ b/src/components/auth/signup/b2b/BusinessForm.jsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import "../common/SignupCommonForm.scss";
 import SignupHeader from "../common/SignupHeader.jsx";
 import BrandHeading from "../common/BrandHeading.jsx";
 import Button from "../common/Button.jsx";
+import AddressSearchModal from "./AddressSearchModal.jsx";
 
 function Row({ children }) {
   return <div className="row">{children}</div>;
@@ -25,6 +26,8 @@ export default function BusinessForm({
     watch,
     setError,
     clearErrors,
+    setValue,
+    setFocus,
     formState: { errors, isValid, isSubmitting },
   } = useForm({
     mode: "onChange",
@@ -41,6 +44,8 @@ export default function BusinessForm({
     },
   });
 
+  const [addrModalOpen, setAddrModalOpen] = useState(false);
+
   const onValid = async (data) => {
     await onSubmit?.(data);
   };
@@ -53,6 +58,13 @@ export default function BusinessForm({
 
   const bizNoValue = watch("bizNo") ?? "";
   const showBizNoError = bizNoValue.trim().length > 0 && !!errors.bizNo;
+
+  const handleAddrSelect = ({ zonecode, address }) => {
+    setValue("zip", zonecode, { shouldValidate: true, shouldTouch: true });
+    setValue("addr1", address, { shouldValidate: true, shouldTouch: true });
+    clearErrors(["zip", "addr1"]);
+    setTimeout(() => setFocus("addr2"), 0);
+  };
 
   return (
     <>
@@ -136,15 +148,16 @@ export default function BusinessForm({
               placeholder="우편번호"
               inputMode="numeric"
               autoComplete="postal-code"
+              readOnly
               {...register("zip", { required: true })}
             />
-            {/* TODO: 카카오 주소 API 연결 (우편번호 찾기) */}
-            <Button type="button" variant="ghost">
+            <Button type="button" variant="ghost" onClick={() => setAddrModalOpen(true)}>
               우편번호 찾기
             </Button>
           </Row>
         </div>
 
+        {/* 주소 */}
         <div className="form-field">
           <input
             id="addr1"
@@ -152,10 +165,12 @@ export default function BusinessForm({
             placeholder="주소"
             autoComplete="street-address"
             aria-label="주소"
+            readOnly
             {...register("addr1", { required: true })}
           />
         </div>
 
+        {/* 상세주소 */}
         <div className="form-field">
           <input
             id="addr2"
@@ -174,6 +189,8 @@ export default function BusinessForm({
           다음으로
         </Button>
       </form>
+
+      <AddressSearchModal open={addrModalOpen} onClose={() => setAddrModalOpen(false)} onSelect={handleAddrSelect} />
     </>
   );
 }

--- a/src/components/auth/signup/b2b/BusinessForm.jsx
+++ b/src/components/auth/signup/b2b/BusinessForm.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import "../common/SignupCommonForm.scss";
 import SignupHeader from "../common/SignupHeader.jsx";
@@ -12,11 +12,19 @@ function Row({ children }) {
 // 사업자번호 형식 (하이픈 필수)
 const BIZNO_RE = /^\d{3}-\d{2}-\d{5}$/;
 
-export default function BusinessForm({ defaultValues, onSubmit, submitting, headerOnBack }) {
+export default function BusinessForm({
+  defaultValues,
+  onSubmit,
+  submitting,
+  headerOnBack,
+  bizNoServerError, // 서버 에러 메시지 추가
+}) {
   const {
     register,
     handleSubmit,
     watch,
+    setError,
+    clearErrors,
     formState: { errors, isValid, isSubmitting },
   } = useForm({
     mode: "onChange",
@@ -36,6 +44,12 @@ export default function BusinessForm({ defaultValues, onSubmit, submitting, head
   const onValid = async (data) => {
     await onSubmit?.(data);
   };
+
+  useEffect(() => {
+    if (bizNoServerError) {
+      setError("bizNo", { type: "server", message: bizNoServerError });
+    }
+  }, [bizNoServerError, setError]);
 
   const bizNoValue = watch("bizNo") ?? "";
   const showBizNoError = bizNoValue.trim().length > 0 && !!errors.bizNo;
@@ -82,6 +96,9 @@ export default function BusinessForm({ defaultValues, onSubmit, submitting, head
             {...register("bizNo", {
               required: true,
               validate: (v) => BIZNO_RE.test((v ?? "").trim()) || "*사업자 번호가 일치하지 않습니다.",
+              onChange: () => {
+                if (errors.bizNo?.type === "server") clearErrors("bizNo");
+              },
             })}
           />
           {showBizNoError && (

--- a/src/components/auth/signup/common/SignupCommonForm.jsx
+++ b/src/components/auth/signup/common/SignupCommonForm.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import "./SignupCommonForm.scss";
 import SignupHeader from "./SignupHeader.jsx";
@@ -6,11 +6,19 @@ import BrandHeading from "./BrandHeading.jsx";
 import Button from "./Button.jsx";
 import { ID_RE, PW_RE, ID_MSG, PW_MSG, normalizeId } from "../../authRules.js";
 
-export default function SignupCommonForm({ onSubmit, submitting, submitLabel = "다음으로" }) {
+export default function SignupCommonForm({
+  onSubmit,
+  submitting,
+  submitLabel = "다음으로",
+  idServerError, // 서버 에러 (중복 아이디)
+  onChangeId, // 아이디 입력 변경 시 콜백
+}) {
   const {
     register,
     handleSubmit,
     watch,
+    setError,
+    clearErrors,
     formState: { errors, isValid, isSubmitting },
   } = useForm({
     mode: "onChange",
@@ -25,6 +33,13 @@ export default function SignupCommonForm({ onSubmit, submitting, submitLabel = "
   const onValid = async (data) => {
     await onSubmit?.(data);
   };
+
+  // 서버 에러 처리 (아이디 중복)
+  useEffect(() => {
+    if (idServerError) {
+      setError("username", { type: "server", message: idServerError });
+    }
+  }, [idServerError, setError]);
 
   return (
     <>
@@ -66,6 +81,10 @@ export default function SignupCommonForm({ onSubmit, submitting, submitLabel = "
               required: true,
               setValueAs: normalizeId,
               pattern: { value: ID_RE, message: ID_MSG },
+              onChange: () => {
+                if (errors.username?.type === "server") clearErrors("username");
+                onChangeId?.();
+              },
             })}
           />
           {errors.username && <p className="field-error">{errors.username.message}</p>}

--- a/src/pages/auth/B2BSignupPage.jsx
+++ b/src/pages/auth/B2BSignupPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import SignupCommonForm from "@/components/auth/signup/common/SignupCommonForm";
 import BusinessForm from "@/components/auth/signup/b2b/BusinessForm";
 import { useNavigate } from "react-router-dom";
+import signupApi from "@/apis/auth/signupApi";
 
 const B2BSignupPage = () => {
   const [step, setStep] = useState(1);
@@ -10,19 +11,33 @@ const B2BSignupPage = () => {
   const nav = useNavigate();
 
   // 1단계: 계정 정보 입력 후 2단계로 이동
-  const handleAccountSubmit = async (data) => {
-    const { username, password, nickname } = data;
+  const handleAccountSubmit = ({ username, password, nickname }) => {
     setAccountData({ username, password, nickname });
     setStep(2);
   };
 
-  // 2단계: 사업자 정보 입력 후 가입 완료
-  const handleBusinessSubmit = async (bizData) => {
+  // 2단계: 사업자 정보 입력 후 가입 완료 (API 연동 예정)
+  const handleBusinessSubmit = async () => {
     try {
       setSubmitting(true);
-      // TODO: API 연동
-      console.log("B2B 가입", { account: accountData, business: bizData });
-      nav("/signup/complete");
+
+      const result = await signupApi({
+        loginId: accountData.username,
+        password: accountData.password,
+        nickName: accountData.nickname,
+        role: "owner",
+      });
+
+      if (!result.ok) {
+        console.log("사장님 회원가입 실패:", result.message ?? result.code);
+        return;
+      }
+
+      console.log("사장님 회원가입 완료. 다음 단계에서 가게 등록 API 연결 예정");
+      // TODO: owner/store API 연동
+      //  nav("/signup/complete");
+    } catch (e) {
+      console.log("사장님 회원가입 처리 오류:", e);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/auth/B2BSignupPage.jsx
+++ b/src/pages/auth/B2BSignupPage.jsx
@@ -3,47 +3,89 @@ import SignupCommonForm from "@/components/auth/signup/common/SignupCommonForm";
 import BusinessForm from "@/components/auth/signup/b2b/BusinessForm";
 import { useNavigate } from "react-router-dom";
 import signupApi from "@/apis/auth/signupApi";
+import ownerStoreApi from "@/apis/auth/ownerStoreApi";
+import loginApi from "@/apis/auth/loginApi";
+import { useAuthStore } from "@/store/useAuthStore";
 
 const B2BSignupPage = () => {
   const [step, setStep] = useState(1);
   const [accountData, setAccountData] = useState(null);
+  const [bizNoServerError, setBizNoServerError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const nav = useNavigate();
+  const { login } = useAuthStore();
 
   // 1단계: 계정 정보 입력
   const handleAccountSubmit = ({ username, password, nickname }) => {
     setAccountData({ username, password, nickname });
+    setBizNoServerError("");
     setStep(2);
   };
 
-  // 2단계: 사업자 정보 입력 후 가입 완료 (API 연동 예정)
-  const handleBusinessSubmit = async () => {
+  // 2단계: 사업자 정보 입력 후 가입 완료
+  const handleBusinessSubmit = async (biz) => {
     if (submitting || !accountData) return;
     setSubmitting(true);
+    setBizNoServerError("");
 
-    const result = await signupApi({
+    // (1) 회원가입
+    const created = await signupApi({
       loginId: accountData.username,
       password: accountData.password,
       nickName: accountData.nickname,
       role: "owner",
     });
-
-    setSubmitting(false);
-
-    if (!result) {
-      console.log("사장님 회원가입 실패");
+    if (!created) {
+      setSubmitting(false);
       return;
     }
 
-    console.log("사장님 회원가입 성공:", result);
-    // TODO: 사업자 정보 연동 후 완료 페이지 이동
+    // (2) 자동 로그인 → 토큰 저장
+    const tokens = await loginApi({
+      role: "owner",
+      loginId: accountData.username,
+      password: accountData.password,
+    });
+    if (!tokens) {
+      setSubmitting(false);
+      return;
+    }
+    localStorage.setItem("access_token", tokens.accessToken);
+    localStorage.setItem("refresh_token", tokens.refreshToken);
+    login({ role: "owner" }); // 전역 상태 갱신(선택)
+
+    // (3) 가게 등록 (Authorization 자동 첨부)
+    const saved = await ownerStoreApi({
+      storeName: biz.bizName,
+      representativeName: biz.owner,
+      businessNumber: (biz.bizNo || "").replace(/\D/g, ""), // 하이픈 제거
+      businessType: biz.bizType,
+      businessCategory: biz.bizCategory,
+      addressMain: biz.addr1,
+      addressDetail: biz.addr2,
+      postalCode: biz.zip,
+    });
+
+    setSubmitting(false);
+
+    if (!saved?.ok) {
+      if (saved?.code === 400 && saved?.message) setBizNoServerError(saved.message);
+      return;
+    }
+
+    nav("/signup/complete", { replace: true });
   };
 
   return (
     <div>
       {step === 1 && <SignupCommonForm onSubmit={handleAccountSubmit} submitting={submitting} submitLabel="다음으로" />}
       {step === 2 && (
-        <BusinessForm headerOnBack={() => setStep(1)} onSubmit={handleBusinessSubmit} submitting={submitting} />
+        <BusinessForm
+          headerOnBack={() => setStep(1)}
+          onSubmit={handleBusinessSubmit}
+          submitting={submitting}
+          bizNoServerError={bizNoServerError}
+        />
       )}
     </div>
   );

--- a/src/pages/auth/B2BSignupPage.jsx
+++ b/src/pages/auth/B2BSignupPage.jsx
@@ -10,7 +10,7 @@ const B2BSignupPage = () => {
   const [submitting, setSubmitting] = useState(false);
   const nav = useNavigate();
 
-  // 1단계: 계정 정보 입력 후 2단계로 이동
+  // 1단계: 계정 정보 입력
   const handleAccountSubmit = ({ username, password, nickname }) => {
     setAccountData({ username, password, nickname });
     setStep(2);
@@ -18,35 +18,30 @@ const B2BSignupPage = () => {
 
   // 2단계: 사업자 정보 입력 후 가입 완료 (API 연동 예정)
   const handleBusinessSubmit = async () => {
-    try {
-      setSubmitting(true);
+    if (submitting || !accountData) return;
+    setSubmitting(true);
 
-      const result = await signupApi({
-        loginId: accountData.username,
-        password: accountData.password,
-        nickName: accountData.nickname,
-        role: "owner",
-      });
+    const result = await signupApi({
+      loginId: accountData.username,
+      password: accountData.password,
+      nickName: accountData.nickname,
+      role: "owner",
+    });
 
-      if (!result.ok) {
-        console.log("사장님 회원가입 실패:", result.message ?? result.code);
-        return;
-      }
+    setSubmitting(false);
 
-      console.log("사장님 회원가입 완료. 다음 단계에서 가게 등록 API 연결 예정");
-      // TODO: owner/store API 연동
-      //  nav("/signup/complete");
-    } catch (e) {
-      console.log("사장님 회원가입 처리 오류:", e);
-    } finally {
-      setSubmitting(false);
+    if (!result) {
+      console.log("사장님 회원가입 실패");
+      return;
     }
+
+    console.log("사장님 회원가입 성공:", result);
+    // TODO: 사업자 정보 연동 후 완료 페이지 이동
   };
 
   return (
     <div>
       {step === 1 && <SignupCommonForm onSubmit={handleAccountSubmit} submitting={submitting} submitLabel="다음으로" />}
-
       {step === 2 && (
         <BusinessForm headerOnBack={() => setStep(1)} onSubmit={handleBusinessSubmit} submitting={submitting} />
       )}

--- a/src/pages/auth/B2CSignupPage.jsx
+++ b/src/pages/auth/B2CSignupPage.jsx
@@ -2,30 +2,52 @@ import React, { useState } from "react";
 import SignupCommonForm from "@/components/auth/signup/common/SignupCommonForm";
 import { useNavigate } from "react-router-dom";
 import signupApi from "@/apis/auth/signupApi";
+import loginApi from "@/apis/auth/loginApi";
+import { useAuthStore } from "@/store/useAuthStore";
 
 const B2CSignupPage = () => {
   const nav = useNavigate();
   const [submitting, setSubmitting] = useState(false);
+  const { login } = useAuthStore();
 
   const submit = async ({ username, password, nickname }) => {
     if (submitting) return;
     setSubmitting(true);
 
-    const result = await signupApi({
+    // 1) 회원가입
+    const created = await signupApi({
       loginId: username,
       password,
       nickName: nickname,
       role: "user",
     });
 
-    setSubmitting(false);
-
-    if (!result) {
-      console.log("사용자 회원가입 실패");
+    if (!created) {
+      setSubmitting(false);
+      console.log("회원가입 실패");
       return;
     }
 
-    console.log("사용자 회원가입 성공:", result);
+    // 2) 자동 로그인(토큰 수령)
+    const tokens = await loginApi({
+      role: "user",
+      loginId: username,
+      password,
+    });
+
+    setSubmitting(false);
+
+    if (!tokens) {
+      console.log("자동 로그인 실패");
+      return;
+    }
+
+    // 토큰 저장 + 전역 상태 갱신
+    localStorage.setItem("access_token", tokens.accessToken);
+    localStorage.setItem("refresh_token", tokens.refreshToken);
+    login({ role: "user" });
+
+    // 3) 완료 페이지로 이동
     nav("/signup/complete", { replace: true });
   };
 

--- a/src/pages/auth/B2CSignupPage.jsx
+++ b/src/pages/auth/B2CSignupPage.jsx
@@ -8,13 +8,15 @@ import { useAuthStore } from "@/store/useAuthStore";
 const B2CSignupPage = () => {
   const nav = useNavigate();
   const [submitting, setSubmitting] = useState(false);
+  const [idServerError, setIdServerError] = useState("");
   const { login } = useAuthStore();
 
   const submit = async ({ username, password, nickname }) => {
     if (submitting) return;
     setSubmitting(true);
+    setIdServerError("");
 
-    // 1) 회원가입
+    // (1) 회원가입
     const created = await signupApi({
       loginId: username,
       password,
@@ -23,37 +25,38 @@ const B2CSignupPage = () => {
     });
 
     if (!created) {
+      setIdServerError("이미 사용 중인 아이디입니다.");
       setSubmitting(false);
-      console.log("회원가입 실패");
       return;
     }
 
-    // 2) 자동 로그인(토큰 수령)
-    const tokens = await loginApi({
-      role: "user",
-      loginId: username,
-      password,
-    });
-
+    // (2) 자동 로그인
+    const tokens = await loginApi({ role: "user", loginId: username, password });
     setSubmitting(false);
 
-    if (!tokens) {
-      console.log("자동 로그인 실패");
+    if (!tokens?.tokens) {
+      console.error("자동 로그인 실패");
       return;
     }
 
-    // 토큰 저장 + 전역 상태 갱신
-    localStorage.setItem("access_token", tokens.accessToken);
-    localStorage.setItem("refresh_token", tokens.refreshToken);
+    // (3) 토큰 저장 + 전역 상태 갱신
+    localStorage.setItem("access_token", tokens.tokens.accessToken);
+    localStorage.setItem("refresh_token", tokens.tokens.refreshToken);
     login({ role: "user" });
 
-    // 3) 완료 페이지로 이동
+    // (4) 완료 페이지로 이동
     nav("/signup/complete", { replace: true });
   };
 
   return (
     <div>
-      <SignupCommonForm onSubmit={submit} submitting={submitting} submitLabel="다음으로" />
+      <SignupCommonForm
+        onSubmit={submit}
+        submitting={submitting}
+        submitLabel="다음으로"
+        idServerError={idServerError}
+        onChangeId={() => setIdServerError("")}
+      />
     </div>
   );
 };

--- a/src/pages/auth/B2CSignupPage.jsx
+++ b/src/pages/auth/B2CSignupPage.jsx
@@ -1,17 +1,32 @@
 import React, { useState } from "react";
 import SignupCommonForm from "@/components/auth/signup/common/SignupCommonForm";
 import { useNavigate } from "react-router-dom";
+import signupApi from "@/apis/auth/signupApi";
 
 const B2CSignupPage = () => {
   const nav = useNavigate();
   const [submitting, setSubmitting] = useState(false);
 
-  const submit = async (data) => {
+  const submit = async ({ username, password, nickname }) => {
     try {
       setSubmitting(true);
-      // TODO: API 연동
-      console.log("B2C 가입", data);
-      nav("/signup/complete");
+
+      const result = await signupApi({
+        loginId: username,
+        password,
+        nickName: nickname,
+        role: "user",
+      });
+
+      if (!result?.ok) {
+        console.log("사용자 회원가입 실패:", result?.message ?? result?.code);
+        return;
+      }
+
+      console.log("사용자 회원가입 성공");
+      nav("/signup/complete", { replace: true });
+    } catch (e) {
+      console.log("사용자 회원가입 요청 오류:", e);
     } finally {
       setSubmitting(false);
     }
@@ -19,7 +34,7 @@ const B2CSignupPage = () => {
 
   return (
     <div>
-      <SignupCommonForm onSubmit={submit} submitting={submitting} />
+      <SignupCommonForm onSubmit={submit} submitting={submitting} submitLabel="다음으로" />
     </div>
   );
 };

--- a/src/pages/auth/B2CSignupPage.jsx
+++ b/src/pages/auth/B2CSignupPage.jsx
@@ -8,28 +8,25 @@ const B2CSignupPage = () => {
   const [submitting, setSubmitting] = useState(false);
 
   const submit = async ({ username, password, nickname }) => {
-    try {
-      setSubmitting(true);
+    if (submitting) return;
+    setSubmitting(true);
 
-      const result = await signupApi({
-        loginId: username,
-        password,
-        nickName: nickname,
-        role: "user",
-      });
+    const result = await signupApi({
+      loginId: username,
+      password,
+      nickName: nickname,
+      role: "user",
+    });
 
-      if (!result?.ok) {
-        console.log("사용자 회원가입 실패:", result?.message ?? result?.code);
-        return;
-      }
+    setSubmitting(false);
 
-      console.log("사용자 회원가입 성공");
-      nav("/signup/complete", { replace: true });
-    } catch (e) {
-      console.log("사용자 회원가입 요청 오류:", e);
-    } finally {
-      setSubmitting(false);
+    if (!result) {
+      console.log("사용자 회원가입 실패");
+      return;
     }
+
+    console.log("사용자 회원가입 성공:", result);
+    nav("/signup/complete", { replace: true });
   };
 
   return (


### PR DESCRIPTION
## ✨ 작업 개요

로그인/회원가입 API 연동 및 에러 처리 개선

## 📌 관련 이슈

- close #35 

## 📄 작업 내용

### 회원가입
- 사용자/사장님 회원가입 API 생성 및 연결
- 아이디 중복 시 입력창 하단에 에러 메시지 표시

### 로그인
- 로그인 API 생성 및 연결
- 사용자/사장님 로그인 분리 처리
- 사용자/사장님 역할 불일치 시 에러 처리

### 자동 로그인
- 회원가입 완료 시 자동 로그인 후 토큰 저장 및 전역 상태 갱신

### 가게 정보 등록 API 연동
- 사업자 번호 불일치 시 입력창 하단에 에러 메시지 표시

### 우편번호 찾기 API 사용
- 우편번호 찾기 모달창으로 구현

## 📷 UI 스크린샷 (해당 시)

| 우편번호 모달창 | 사업자번호 에러 |
|--------|--------|
| <img width="658" height="1360" alt="image" src="https://github.com/user-attachments/assets/70e43824-1b0f-459f-958f-8820c5280d22" />  | <img width="662" height="1368" alt="image" src="https://github.com/user-attachments/assets/bc69b258-7caa-4f5f-b0f2-7756c1f6f479" /> |

| 아이디 중복 에러 |
|--------|
| <img width="330" height="684" alt="image" src="https://github.com/user-attachments/assets/ad312f3b-2573-4a11-8b53-874ab08044f1" /> |



## 💬 기타 사항

- B2C 회원가입은 1단계 아이디 중복 시 바로 에러 메시지 표시
- B2B 회원가입은 1단계에서 회원가입+자동로그인 처리 후 2단계에서 가게 등록 진행