### PR TITLE
Feat/api-user-mypage: 마이페이지 관련 API 연결 #39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.11.0",
         "html2canvas": "^1.4.1",
         "qr-scanner": "^1.4.2",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-daum-postcode": "^3.2.0",
         "react-dom": "^19.1.0",
@@ -3218,6 +3219,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/offscreencanvas": "^2019.6.4"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.11.0",
     "html2canvas": "^1.4.1",
     "qr-scanner": "^1.4.2",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-daum-postcode": "^3.2.0",
     "react-dom": "^19.1.0",

--- a/src/components/b2b/mypage/B2BMyPageScreen.jsx
+++ b/src/components/b2b/mypage/B2BMyPageScreen.jsx
@@ -11,6 +11,10 @@ import { useAuthStore } from "@/store/useAuthStore";
 export const B2BMyPageScreen = () => {
   const [isSubs, setIsSubs] = useState(false);
   const [logoutModal, setLogoutModal] = useState(false);
+  const [profile, setProfile] = useState({
+    nickName: "김구밍",
+    loginId: "lion1234",
+  });
   const nav = useNavigate();
   const { logout } = useAuthStore();
 
@@ -34,7 +38,7 @@ export const B2BMyPageScreen = () => {
   };
 
   useEffect(() => {
-    const getFetch = async () => {
+    const getSubscription = async () => {
       try {
         const res = await api.get("owner/subscription");
         if (res.data.isSuccess && res.data.data.status == "ACTIVE") setIsSubs(true);
@@ -43,7 +47,16 @@ export const B2BMyPageScreen = () => {
         setIsSubs(false);
       }
     };
-    getFetch();
+    const getProfile = async () => {
+      try {
+        const res = await api.get("owner/mypage");
+        if (res.data.isSuccess) setProfile(res.data.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    getProfile();
+    getSubscription();
   }, []);
 
   return (
@@ -54,7 +67,7 @@ export const B2BMyPageScreen = () => {
       </header>
 
       {/* 프로필 카드 */}
-      <Profile img={profileImg} name={"김구밍"} id={"Lion1234"} />
+      <Profile img={profileImg} name={profile.nickName} id={profile.loginId} />
 
       {/* 구독 배너 */}
       {!isSubs ? (

--- a/src/components/b2b/mypage/download/Download.jsx
+++ b/src/components/b2b/mypage/download/Download.jsx
@@ -6,16 +6,31 @@ import { useNavigate } from "react-router-dom";
 import { Modal } from "@/components/common/Modal";
 import { mascotHappy } from "@/assets";
 import { useDownload } from "@/hooks/useDownload";
+import { QRCodeCanvas } from "qrcode.react";
+import { useEffect, useState } from "react";
+import api from "@/apis/Instance";
 
 export const Download = () => {
   const { ref, download, downModal, setDownModal } = useDownload("test.png");
-
+  const [QrData, setQrData] = useState({
+    characterId: 1,
+    qrCode: "",
+  });
   const nav = useNavigate();
 
   const downloadHandle = () => {
     download();
     setDownModal(true);
   };
+
+  // QR 데이터 API 가져오기(캐릭터번호, 해금을 위한 식별 QR코드 데이터)
+  useEffect(() => {
+    const getQrData = async () => {
+      const res = await api.get("owner/store/qr");
+      if (res.data.isSuccess) setQrData(res.data.data);
+    };
+    getQrData();
+  }, []);
 
   return (
     <div className="download">
@@ -31,9 +46,12 @@ export const Download = () => {
           사용자들이 캐릭터 도감을 수집하게 해주세요!
         </span>
 
-        {/* TODO QR 이미지 추가 로직 구현 */}
-        {/* <img src={} alt="qr" ref={ref} /> */}
-        <MdOutlineQrCode2 className="qr-icon" ref={ref} />
+        <QRCodeCanvas
+          value={`https://storey-6jeon.vercel.app/detail/${QrData.characterId}?code=${QrData.qrCode}`}
+          className="qr-icon"
+          ref={ref}
+          size={300}
+        />
         <FiDownload className="down-icon" onClick={downloadHandle} />
       </div>
       {downModal && (

--- a/src/components/b2b/mypage/download/Download.scss
+++ b/src/components/b2b/mypage/download/Download.scss
@@ -5,7 +5,7 @@
   @include flex(column);
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
   position: relative;
   .down-header {
     @include flex($align-items: flex-end, $justify-content: space-between, $gap: 20px);
@@ -43,10 +43,11 @@
     @include flex(column, $gap: vh(22px));
     .caption {
       color: #8d8d8d;
-      font-size: rem(18px);
-      font-weight: 600;
-      letter-spacing: -0.45px;
       text-align: center;
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 24px; /* 150% */
+      letter-spacing: -0.4px;
     }
     .qr-icon {
       width: 365px;

--- a/src/components/common/mypage/Profile.scss
+++ b/src/components/common/mypage/Profile.scss
@@ -10,7 +10,7 @@
     height: 70px;
   }
   .profile-content {
-    @include flex(column, $gap: vh(10px));
+    @include flex(column, flex-start, $gap: vh(10px));
     .profile-name {
       color: $color-font-main;
       font-size: rem(20px);

--- a/src/components/user/character-detail/CharacterDetail.jsx
+++ b/src/components/user/character-detail/CharacterDetail.jsx
@@ -1,6 +1,6 @@
 import api from "@/apis/Instance";
 import styles from "./CharacterDetail.module.scss";
-import { logoTest, shadowChar } from "@/assets";
+import { shadowChar } from "@/assets";
 import { Modal } from "@/components/common/Modal";
 import { useDownload } from "@/hooks/useDownload";
 import { useEffect, useState } from "react";
@@ -8,19 +8,6 @@ import { FiDownload } from "react-icons/fi";
 import { HiCamera } from "react-icons/hi2";
 import { IoIosArrowBack } from "react-icons/io";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-
-const mock = {
-  characterId: 1,
-  storeName: "참새방앗간",
-  addressMain: "서울 성북구 삼선교로 11길 20",
-  addressDetail: "1층",
-  tagline: "“들어왔으면, 한 잔부터 받아요. 오늘은 어땠어요?”",
-  imageUrl: logoTest,
-  name: "짹이",
-  description: "수다쟁이 & 다정다감하고, ‘하루쯤은 떠들고 웃고 맛있는 걸 마셔야지.’가 좌우명이다.",
-  narrativeSummary:
-    " “하루 한 끼, 진심으로 위로받는 식사”를 만들기 위해 퇴사 후 작은 가게를 연 사장님의 이야기가 담겨 있는 캐릭터로 하루 30개 한정의 수제버거, 그리고 ‘고추마요 쉬림프버거’에 담긴 정성이 이 가게의 심장이다.",
-};
 
 export const CharacterDetail = () => {
   const [detail, setDetail] = useState({
@@ -45,13 +32,12 @@ export const CharacterDetail = () => {
   useEffect(() => {
     const getDetailData = async () => {
       try {
-        const res = await api.get(`user/characters/${id}`);
+        const res = await api.get(`characters/${id}`);
         if (res.data.isSuccess) setDetail(res.data.data);
       } catch (error) {
         console.error(error);
       }
     };
-    // setDetail(mock);
     getDetailData();
   }, [id]);
 

--- a/src/components/user/character-detail/CharacterDetail.jsx
+++ b/src/components/user/character-detail/CharacterDetail.jsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { FiDownload } from "react-icons/fi";
 import { HiCamera } from "react-icons/hi2";
 import { IoIosArrowBack } from "react-icons/io";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 const mock = {
   characterId: 1,
@@ -34,11 +34,14 @@ export const CharacterDetail = () => {
     addressMain: "",
     addressDetail: "",
   });
-  const [modalOpen, setModalOpen] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
   const { ref, download, setDownModal, downModal } = useDownload("test.png");
   const nav = useNavigate();
   const { id } = useParams();
+  const [searchParams] = useSearchParams(); // qr 코드 데이터를 URL 쿼리 param으로 받아오기 위한 훅
+  const code = searchParams.get("code");
 
+  // 상세정보 가져오기 API
   useEffect(() => {
     const getDetailData = async () => {
       try {
@@ -51,6 +54,23 @@ export const CharacterDetail = () => {
     // setDetail(mock);
     getDetailData();
   }, [id]);
+
+  // 잠겨 있는 가게일 경우 code확인 후 해제한 뒤 모달 보여주기
+  useEffect(() => {
+    if (code) {
+      const postUnlockFetch = async () => {
+        try {
+          const res = await api.post("/user/stores/unlock", { qrCode: code });
+          console.log(res.data);
+
+          if (res.data.isSuccess) setModalOpen(true);
+        } catch (error) {
+          return;
+        }
+      };
+      postUnlockFetch();
+    }
+  }, [code]);
 
   return (
     <div className={styles.container}>
@@ -74,6 +94,7 @@ export const CharacterDetail = () => {
             <span>{detail.tagline}</span>
           </div>
           <div className={styles.character}>
+            {/* TODO crossOrigin="anonymous" 추가 고려. CDN 설정 후 처리 예정 */}
             <img src={detail.imageUrl} className={styles.char} alt="" />
             <img src={shadowChar} className={styles.charShadow} alt="" />
           </div>

--- a/src/components/user/character-detail/CharacterDetail.jsx
+++ b/src/components/user/character-detail/CharacterDetail.jsx
@@ -1,3 +1,4 @@
+import api from "@/apis/Instance";
 import styles from "./CharacterDetail.module.scss";
 import { logoTest, shadowChar } from "@/assets";
 import { Modal } from "@/components/common/Modal";
@@ -6,29 +7,50 @@ import { useEffect, useState } from "react";
 import { FiDownload } from "react-icons/fi";
 import { HiCamera } from "react-icons/hi2";
 import { IoIosArrowBack } from "react-icons/io";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 const mock = {
-  title: "참새방앗간",
-  address: "서울 성북구 삼선교로 11길 20 1층",
-  message: "“들어왔으면, 한 잔부터 받아요. 오늘은 어땠어요?”",
-  img: logoTest,
+  characterId: 1,
+  storeName: "참새방앗간",
+  addressMain: "서울 성북구 삼선교로 11길 20",
+  addressDetail: "1층",
+  tagline: "“들어왔으면, 한 잔부터 받아요. 오늘은 어땠어요?”",
+  imageUrl: logoTest,
   name: "짹이",
-  caption: "수다쟁이 & 다정다감하고, ‘하루쯤은 떠들고 웃고 맛있는 걸 마셔야지.’가 좌우명이다.",
-  story:
+  description: "수다쟁이 & 다정다감하고, ‘하루쯤은 떠들고 웃고 맛있는 걸 마셔야지.’가 좌우명이다.",
+  narrativeSummary:
     " “하루 한 끼, 진심으로 위로받는 식사”를 만들기 위해 퇴사 후 작은 가게를 연 사장님의 이야기가 담겨 있는 캐릭터로 하루 30개 한정의 수제버거, 그리고 ‘고추마요 쉬림프버거’에 담긴 정성이 이 가게의 심장이다.",
 };
 
 export const CharacterDetail = () => {
-  const [detail, setDetail] = useState({});
+  const [detail, setDetail] = useState({
+    characterId: null,
+    imageUrl: "",
+    tagline: "",
+    name: "",
+    description: "",
+    narrativeSummary: "",
+    storeName: "",
+    addressMain: "",
+    addressDetail: "",
+  });
   const [modalOpen, setModalOpen] = useState(true);
   const { ref, download, setDownModal, downModal } = useDownload("test.png");
   const nav = useNavigate();
+  const { id } = useParams();
 
   useEffect(() => {
-    // TODO api 통신
-    setDetail(mock);
-  }, []);
+    const getDetailData = async () => {
+      try {
+        const res = await api.get(`user/characters/${id}`);
+        if (res.data.isSuccess) setDetail(res.data.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    // setDetail(mock);
+    getDetailData();
+  }, [id]);
 
   return (
     <div className={styles.container}>
@@ -36,25 +58,27 @@ export const CharacterDetail = () => {
       <div className={styles.header}>
         <IoIosArrowBack className={styles.icon} onClick={() => nav(-1)} />
         <span className={styles.headerTitle}>내가 모은 캐릭터</span>
-        <HiCamera className={styles.iconCamera} onClick={() => nav("/capture", { state: mock })} />
+        <HiCamera className={styles.iconCamera} onClick={() => nav("/capture", { state: detail })} />
       </div>
 
       {/* 메인 콘텐츠(제목, 카드, 다운로드) */}
       <div className={styles.content}>
         <div className={styles.title}>
-          <span className={styles.headline}>{detail.title}</span>
-          <span className={styles.address}>{detail.address}</span>
+          <span className={styles.headline}>{detail.storeName}</span>
+          <span className={styles.address}>
+            {detail.addressMain} {detail.addressDetail}
+          </span>
         </div>
         <div className={styles.card} ref={ref}>
           <div className={styles.message}>
-            <span>{detail.message}</span>
+            <span>{detail.tagline}</span>
           </div>
           <div className={styles.character}>
-            <img src={detail.img} className={styles.char} alt="" />
+            <img src={detail.imageUrl} className={styles.char} alt="" />
             <img src={shadowChar} className={styles.charShadow} alt="" />
           </div>
           <span className={styles.name}>{detail.name}</span>
-          <span className={styles.caption}>{detail.caption}</span>
+          <span className={styles.caption}>{detail.description}</span>
         </div>
         <div className={styles.download} onClick={download}>
           <FiDownload className={styles.icon} />
@@ -65,7 +89,7 @@ export const CharacterDetail = () => {
       {/* 가게 요약 서사 */}
       <div className={styles.summary}>
         <span className={styles.summaryTitle}>가게 요약 서사</span>
-        <div className={styles.summaryText}>{detail.story}</div>
+        <div className={styles.summaryText}>{detail.narrativeSummary}</div>
       </div>
       {modalOpen && (
         <Modal

--- a/src/components/user/character-detail/CharacterDetail.module.scss
+++ b/src/components/user/character-detail/CharacterDetail.module.scss
@@ -72,7 +72,8 @@
         background: white;
         padding: vh(19.1px) 10px;
         border-radius: 23.291px;
-        width: 100%;
+        min-width: 150px;
+        margin-bottom: 10px;
         span {
           text-align: center;
           font-size: 1rem;
@@ -97,6 +98,8 @@
         position: relative;
         @include flex();
         .char {
+          width: 200px;
+          height: auto;
         }
         .charShadow {
           position: absolute;

--- a/src/components/user/mypage/UserMyPageScreen.jsx
+++ b/src/components/user/mypage/UserMyPageScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { logoText, profileImg } from "@/assets";
 import { useNavigate } from "react-router-dom";
 import { MyPageListItem } from "@/components/common/mypage/MyPageListItem";
@@ -9,7 +9,11 @@ import api from "@/apis/Instance";
 import { useAuthStore } from "@/store/useAuthStore";
 
 export const UserMyPageScreen = () => {
-  const [collection, setCollection] = useState([]);
+  const [collection, setCollection] = useState(0);
+  const [profile, setProfile] = useState({
+    nickName: "김구밍",
+    loginId: "lion1234",
+  });
   const [logoutModal, setLogoutModal] = useState(false);
   const nav = useNavigate();
   const { logout } = useAuthStore();
@@ -27,6 +31,27 @@ export const UserMyPageScreen = () => {
     }
   };
 
+  useEffect(() => {
+    const getCollection = async () => {
+      try {
+        const res = await api.get("user/collection");
+        if (res.data.isSuccess) setCollection(res.data.data.totalCount);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    const getProfile = async () => {
+      try {
+        const res = await api.get("user/mypage");
+        if (res.data.isSuccess) setProfile(res.data.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    getCollection();
+    getProfile();
+  }, []);
+
   return (
     <div className="container">
       {/* Header */}
@@ -35,9 +60,9 @@ export const UserMyPageScreen = () => {
       </header>
 
       {/* 프로필 카드 */}
-      <Profile img={profileImg} name={"김구밍"} id={"Lion1234"} />
+      <Profile img={profileImg} name={profile.nickName} id={profile.loginId} />
       <div className="collection-button" onClick={() => nav("/mypage/user/collection")}>
-        내가 모은 캐릭터 {collection.length}개
+        내가 모은 캐릭터 {collection}개
       </div>
 
       {/* 네비게이션, 로그아웃 */}

--- a/src/components/user/mypage/collection/Collection.jsx
+++ b/src/components/user/mypage/collection/Collection.jsx
@@ -1,7 +1,7 @@
 import { IoIosArrowBack } from "react-icons/io";
 import { useNavigate } from "react-router-dom";
 import "./Collection.scss";
-import { logoEmpty, mascotBubble, testlogo } from "@/assets";
+import { logoEmpty, mascotBubble } from "@/assets";
 import { useEffect, useState } from "react";
 import api from "@/apis/Instance";
 
@@ -29,8 +29,8 @@ export const Collection = () => {
         setLoading(false);
       }
     };
-    setCollectionData(mockData);
-    // getCollectionData();
+    // setCollectionData(mockData);
+    getCollectionData();
   }, []);
 
   useEffect(() => {
@@ -91,26 +91,3 @@ export const Collection = () => {
     </div>
   );
 };
-
-const mockData = [
-  {
-    storeId: 1,
-    characterImageUrl: testlogo,
-    storeName: "한성돼",
-  },
-  {
-    storeId: 2,
-    characterImageUrl: testlogo,
-    storeName: "한성돼asdadsdd",
-  },
-  {
-    storeId: 3,
-    characterImageUrl: testlogo,
-    storeName: "한성돼",
-  },
-  {
-    storeId: 4,
-    characterImageUrl: testlogo,
-    storeName: "한성돼",
-  },
-];

--- a/src/components/user/mypage/collection/Collection.jsx
+++ b/src/components/user/mypage/collection/Collection.jsx
@@ -3,16 +3,34 @@ import { useNavigate } from "react-router-dom";
 import "./Collection.scss";
 import { logoEmpty, mascotBubble, testlogo } from "@/assets";
 import { useEffect, useState } from "react";
+import api from "@/apis/Instance";
 
 export const Collection = () => {
-  const [collectionData, setCollectionData] = useState([]);
+  const [collectionData, setCollectionData] = useState([
+    {
+      characterId: null,
+      storeId: null,
+      storeName: "",
+      characterImageUrl: "",
+    },
+  ]);
   const [loading, setLoading] = useState(true);
   const [modalState, setModalState] = useState({ open: false, visible: false });
   const nav = useNavigate();
 
   useEffect(() => {
+    const getCollectionData = async () => {
+      try {
+        const res = await api.get("user/collection");
+        if (res.data.isSuccess) setCollectionData(res.data.data.collectedCharacters);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
     setCollectionData(mockData);
-    setLoading(false);
+    // getCollectionData();
   }, []);
 
   useEffect(() => {
@@ -42,11 +60,11 @@ export const Collection = () => {
       ) : (
         <div className="collection-list">
           {collectionData.map((data) => (
-            <div className="collection-list-item" key={data.id}>
+            <div className="collection-list-item" key={data.storeId}>
               <div className="collection-list-img">
-                <img src={data.imgUrl} alt="test" onClick={() => nav(`/detail/${data.id}`)} />
+                <img src={data.characterImageUrl} alt="test" onClick={() => nav(`/detail/${1}`)} />
               </div>
-              <div className="collection-list-title">{data.title}</div>
+              <div className="collection-list-title">{data.storeName}</div>
             </div>
           ))}
         </div>
@@ -76,68 +94,23 @@ export const Collection = () => {
 
 const mockData = [
   {
-    id: 1,
-    imgUrl: testlogo,
-    title: "한성돼",
+    storeId: 1,
+    characterImageUrl: testlogo,
+    storeName: "한성돼",
   },
   {
-    id: 2,
-    imgUrl: testlogo,
-    title: "한성돼asdadsdd",
+    storeId: 2,
+    characterImageUrl: testlogo,
+    storeName: "한성돼asdadsdd",
   },
   {
-    id: 3,
-    imgUrl: testlogo,
-    title: "한성돼",
+    storeId: 3,
+    characterImageUrl: testlogo,
+    storeName: "한성돼",
   },
   {
-    id: 4,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 5,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 6,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 7,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 8,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 9,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 10,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 11,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 12,
-    imgUrl: testlogo,
-    title: "한성돼",
-  },
-  {
-    id: 13,
-    imgUrl: testlogo,
-    title: "한성돼",
+    storeId: 4,
+    characterImageUrl: testlogo,
+    storeName: "한성돼",
   },
 ];

--- a/src/components/user/share-char/Capture.jsx
+++ b/src/components/user/share-char/Capture.jsx
@@ -63,14 +63,16 @@ export const Capture = () => {
           {/* 캡쳐할 영역(비디오 포함) */}
           <div className={styles.captureArea} ref={ref}>
             <div className={styles.title}>
-              <span className={styles.headline}>{state?.title}</span>
-              <span className={styles.address}>{state?.address}</span>
+              <span className={styles.headline}>{state?.storeName}</span>
+              <span className={styles.address}>
+                {state?.addressMain} {state?.addressDetail}
+              </span>
             </div>
             <div className={styles.card}>
               <div className={styles.message}>
-                <span>{state?.message}</span>
+                <span>{state?.tagline}</span>
               </div>
-              <img src={state?.img} className={styles.img} alt="" />
+              <img src={state?.imageUrl} className={styles.img} alt="" />
             </div>
             <video ref={videoRef} className={styles.video} autoPlay playsInline />
           </div>

--- a/src/components/user/share-char/Capture.module.scss
+++ b/src/components/user/share-char/Capture.module.scss
@@ -103,6 +103,8 @@
             padding: vh(14.491px) 10.603px;
             border-radius: 23.291px;
             max-width: 147px;
+            width: 100%;
+            margin-bottom: 10px;
             span {
               text-align: center;
               font-size: rem(12.37px);


### PR DESCRIPTION
## ✨ 작업 개요
마이페이지 관련 API 연결
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

## 📌 관련 이슈

- close #39 

## 📄 작업 내용
### 손님
- 마이페이지 도감 캐릭터 개수 API 연결
- 마이페이지 프로필 API 연결
- 도감 페이지 목록 API 연결
- 캐릭터 상세보기 API 연결
- 캐릭터 잠금 해제 API 연결(QR 스캔 후 수집 요청 API)
  - URL 쿼리 파라미터에 code 값(`/character/1?code=asdad`)으로 각 가게의 고유 QR 데이터를 확인하여 잠금 해제 요청

### 사장님
- 마이페이지 프로필 API 연결
- QR 다운로드 페이지 API 연결
  - QR 코드 생성 API로 각 가게의 고유 QR 데이터를 받음. 이 데이터를 수집 요청 API 바디값에 넣어줘야 함
  - QR 코드를 프론트에서 생성하여 링크에 캐릭터 상세보기 페이지로 이동(쿼리 파라미터 code에 QR 데이터 삽입)
  - QR 코드 생성은 [qrcode.react](https://www.npmjs.com/package/qrcode.react) 라이브러리 사용 
    - html2canvas와 연결하려면 QRCodeSVG가 아닌 QRCodeCanvas로 사용


## 📷 UI 스크린샷 (해당 시)

<!-- 전/후 비교 이미지 등 첨부 -->

## 💬 기타 사항
- 캐릭터 이미지 배경 제거를 프론트쪽에서 고민해봐야할 듯..? 
- s3에서 가져온 이미지는 html2canvas CORS 오류로 다운로드되지 않음.. 추후 백엔드와 소통 후 CORS 및 CDN(cloud front?) 설정 해야할 듯
  - 따라서 이 브랜치를 병합한다면 추후 꼭 해결해야 함
 
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
